### PR TITLE
 Add mutating webhook for workflows

### DIFF
--- a/apis/engine/v1alpha1/validator.go
+++ b/apis/engine/v1alpha1/validator.go
@@ -3,3 +3,10 @@ package v1alpha1
 func (r Workflow) IsValid() error {
 	return nil
 }
+
+func (r *Workflow) SetDefaults() (*Workflow, error) {
+	if r.Spec.ExecutionOrder == "" {
+		r.Spec.ExecutionOrder = ExecutionOrderSerial
+	}
+	return r, nil
+}

--- a/chart/kubeci-engine/templates/apiregistration.yaml
+++ b/chart/kubeci-engine/templates/apiregistration.yaml
@@ -7,14 +7,33 @@
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:
-  name: v1alpha1.admission.engine.kube.ci
+  name: v1alpha1.validators.engine.kube.ci
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ template "kubeci-engine.name" . }}"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
 spec:
-  group: admission.engine.kube.ci
+  group: validators.engine.kube.ci
+  version: v1alpha1
+  service:
+    namespace: {{ .Release.Namespace }}
+    name: {{ template "kubeci-engine.fullname" . }}
+  caBundle: {{ b64enc $ca.Cert }}
+  groupPriorityMinimum: {{ .Values.apiserver.groupPriorityMinimum }}
+  versionPriority: {{ .Values.apiserver.versionPriority }}
+---
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1alpha1.mutators.engine.kube.ci
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: "{{ template "kubeci-engine.name" . }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+spec:
+  group: mutators.engine.kube.ci
   version: v1alpha1
   service:
     namespace: {{ .Release.Namespace }}

--- a/chart/kubeci-engine/templates/cleaner.yaml
+++ b/chart/kubeci-engine/templates/cleaner.yaml
@@ -26,6 +26,6 @@ spec:
         command:
           - sh
           - -c
-          - "sleep 2; kubectl delete validatingwebhookconfigurations admission.engine.kube.ci || true"
+          - "sleep 2; kubectl delete validatingwebhookconfigurations validators.engine.kube.ci || true; kubectl delete mutatingwebhookconfigurations mutators.engine.kube.ci || true"
         imagePullPolicy: IfNotPresent
       restartPolicy: Never

--- a/chart/kubeci-engine/templates/mutating-webhook.yaml
+++ b/chart/kubeci-engine/templates/mutating-webhook.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.apiserver.enableValidatingWebhook }}
+{{- if .Values.apiserver.enableMutatingWebhook }}
 apiVersion: admissionregistration.k8s.io/v1beta1
-kind: ValidatingWebhookConfiguration
+kind: MutatingWebhookConfiguration
 metadata:
-  name: validators.engine.kube.ci
+  name: mutators.engine.kube.ci
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ template "kubeci-engine.name" . }}"
@@ -12,12 +12,12 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
 webhooks:
-- name: workflow.validators.engine.kube.ci
+- name: workflow.mutators.engine.kube.ci
   clientConfig:
     service:
       namespace: default
       name: kubernetes
-      path: /apis/validators.engine.kube.ci/v1alpha1/workflows
+      path: /apis/mutators.engine.kube.ci/v1alpha1/workflows
     caBundle: {{ b64enc .Values.apiserver.ca }}
   rules:
   - operations:
@@ -29,22 +29,5 @@ webhooks:
     - "*"
     resources:
     - workflows
-  failurePolicy: Fail
-- name: workplan.validators.engine.kube.ci
-  clientConfig:
-    service:
-      namespace: default
-      name: kubernetes
-      path: /apis/validators.engine.kube.ci/v1alpha1/workplans
-    caBundle: {{ b64enc .Values.apiserver.ca }}
-  rules:
-  - operations:
-    - UPDATE
-    apiGroups:
-    - engine.kube.ci
-    apiVersions:
-    - "*"
-    resources:
-    - workplans
   failurePolicy: Fail
 {{ end }}

--- a/docs/setup/uninstall.md
+++ b/docs/setup/uninstall.md
@@ -6,9 +6,9 @@ To uninstall KubeCI engine, run the following command:
 $ curl -fsSL https://raw.githubusercontent.com/kube-ci/engine/0.1.0/hack/deploy/install.sh \
     | bash -s -- --uninstall [--namespace=NAMESPACE]
 
-validatingwebhookconfiguration.admissionregistration.k8s.io "admission.engine.kube.ci" deleted
+validatingwebhookconfiguration.admissionregistration.k8s.io "validators.engine.kube.ci" deleted
 No resources found
-apiservice.apiregistration.k8s.io "v1alpha1.admission.engine.kube.ci" deleted
+apiservice.apiregistration.k8s.io "v1alpha1.validators.engine.kube.ci" deleted
 apiservice.apiregistration.k8s.io "v1alpha1.extensions.kube.ci" deleted
 deployment.extensions "kubeci-engine" deleted
 service "kubeci-engine" deleted

--- a/hack/deploy/apiservices.yaml
+++ b/hack/deploy/apiservices.yaml
@@ -2,12 +2,29 @@
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:
-  name: v1alpha1.admission.engine.kube.ci
+  name: v1alpha1.validators.engine.kube.ci
   labels:
     app: kubeci-engine
 spec:
   caBundle: ${SERVICE_SERVING_CERT_CA}
-  group: admission.engine.kube.ci
+  group: validators.engine.kube.ci
+  groupPriorityMinimum: 1000
+  versionPriority: 15
+  service:
+    name: kubeci-engine
+    namespace: ${KUBECI_ENGINE_NAMESPACE}
+  version: v1alpha1
+---
+# register as aggregated apiserver
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1alpha1.mutators.engine.kube.ci
+  labels:
+    app: kubeci-engine
+spec:
+  caBundle: ${SERVICE_SERVING_CERT_CA}
+  group: mutators.engine.kube.ci
   groupPriorityMinimum: 1000
   versionPriority: 15
   service:

--- a/hack/deploy/install.sh
+++ b/hack/deploy/install.sh
@@ -335,9 +335,9 @@ fi
 if [ "$KUBECI_ENGINE_ENABLE_VALIDATING_WEBHOOK" = true ]; then
   ${SCRIPT_LOCATION}hack/deploy/validating-webhook.yaml | $ONESSL envsubst | kubectl apply -f -
 fi
-# if [ "$KUBECI_ENGINE_ENABLE_MUTATING_WEBHOOK" = true ]; then
-#   ${SCRIPT_LOCATION}hack/deploy/mutating-webhook.yaml | $ONESSL envsubst | kubectl apply -f -
-# fi
+if [ "$KUBECI_ENGINE_ENABLE_MUTATING_WEBHOOK" = true ]; then
+  ${SCRIPT_LOCATION}hack/deploy/mutating-webhook.yaml | $ONESSL envsubst | kubectl apply -f -
+fi
 
 echo
 echo "waiting until kubeci-engine operator deployment is ready"
@@ -348,7 +348,7 @@ $ONESSL wait-until-ready deployment kubeci-engine --namespace $KUBECI_ENGINE_NAM
 
 if [ "$KUBECI_ENGINE_ENABLE_APISERVER" = true ]; then
   echo "waiting until kubeci-engine apiservice is available"
-  $ONESSL wait-until-ready apiservice v1alpha1.admission.engine.kube.ci || {
+  $ONESSL wait-until-ready apiservice v1alpha1.validators.engine.kube.ci || {
     echo "KUBECI-ENGINE apiservice failed to be ready"
     exit 1
   }

--- a/hack/deploy/mutating-webhook.yaml
+++ b/hack/deploy/mutating-webhook.yaml
@@ -1,0 +1,25 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutators.engine.kube.ci
+  labels:
+    app: kubeci-engine
+webhooks:
+- name: workflow.mutators.engine.kube.ci
+  clientConfig:
+    service:
+      namespace: default
+      name: kubernetes
+      path: /apis/mutators.engine.kube.ci/v1alpha1/workflows
+    caBundle: ${KUBE_CA}
+  rules:
+  - operations:
+    - CREATE
+    - UPDATE
+    apiGroups:
+    - engine.kube.ci
+    apiVersions:
+    - "*"
+    resources:
+    - workflows
+  failurePolicy: Fail

--- a/hack/deploy/rbac-list.yaml
+++ b/hack/deploy/rbac-list.yaml
@@ -9,6 +9,7 @@ rules:
   - admissionregistration.k8s.io
   resources:
   - validatingwebhookconfigurations
+  - mutatingwebhookconfigurations
   verbs: ["delete", "list", "watch", "patch"]
 - apiGroups:
   - apiextensions.k8s.io

--- a/hack/deploy/validating-webhook.yaml
+++ b/hack/deploy/validating-webhook.yaml
@@ -1,16 +1,16 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: admission.engine.kube.ci
+  name: validators.engine.kube.ci
   labels:
     app: kubeci-engine
 webhooks:
-- name: workflow.admission.engine.kube.ci
+- name: workflow.validators.engine.kube.ci
   clientConfig:
     service:
       namespace: default
       name: kubernetes
-      path: /apis/admission.engine.kube.ci/v1alpha1/workflows
+      path: /apis/validators.engine.kube.ci/v1alpha1/workflows
     caBundle: ${KUBE_CA}
   rules:
   - operations:
@@ -23,12 +23,12 @@ webhooks:
     resources:
     - workflows
   failurePolicy: Fail
-- name: workplan.admission.engine.kube.ci
+- name: workplan.validators.engine.kube.ci
   clientConfig:
     service:
       namespace: default
       name: kubernetes
-      path: /apis/admission.engine.kube.ci/v1alpha1/workplans
+      path: /apis/validators.engine.kube.ci/v1alpha1/workplans
     caBundle: ${KUBE_CA}
   rules:
   - operations:

--- a/hack/dev/apiregistration.yaml
+++ b/hack/dev/apiregistration.yaml
@@ -36,12 +36,29 @@ subsets:
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:
-  name: v1alpha1.admission.engine.kube.ci
+  name: v1alpha1.validators.engine.kube.ci
   labels:
     app: kubeci-engine-dev-apiserver
 spec:
   insecureSkipTLSVerify: true
-  group: admission.engine.kube.ci
+  group: validators.engine.kube.ci
+  groupPriorityMinimum: 1000
+  versionPriority: 15
+  service:
+    name: kubeci-engine-dev-apiserver
+    namespace: ${KUBECI_ENGINE_NAMESPACE}
+  version: v1alpha1
+---
+# register as aggregated apiserver
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1alpha1.mutators.engine.kube.ci
+  labels:
+    app: kubeci-engine-dev-apiserver
+spec:
+  insecureSkipTLSVerify: true
+  group: mutators.engine.kube.ci
   groupPriorityMinimum: 1000
   versionPriority: 15
   service:

--- a/pkg/cmds/server/start.go
+++ b/pkg/cmds/server/start.go
@@ -67,8 +67,9 @@ func (o KubeciOptions) Config() (*server.KubeciServerConfig, error) {
 	serverConfig.OpenAPIConfig.Info.Version = v1alpha1.SchemeGroupVersion.Version
 	serverConfig.OpenAPIConfig.IgnorePrefixes = []string{
 		"/swaggerapi",
-		"/apis/admission.engine.kube.ci/v1alpha1/workflows",
-		"/apis/admission.engine.kube.ci/v1alpha1/workplans",
+		"/apis/validators.engine.kube.ci/v1alpha1/workflows",
+		"/apis/validators.engine.kube.ci/v1alpha1/workplans",
+		"/apis/mutators.engine.kube.ci/v1alpha1/workflows",
 		"/apis/extensions.kube.ci/v1alpha1",
 	}
 

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -16,7 +16,8 @@ import (
 )
 
 const (
-	validatingWebhook = "admission.engine.kube.ci"
+	validatingWebhook = "validators.engine.kube.ci"
+	mutatingWebhook   = "mutators.engine.kube.ci"
 )
 
 type config struct {
@@ -65,6 +66,9 @@ func (c *Config) New() (*Controller, error) {
 		return nil, err
 	}
 	if err := reg_util.UpdateValidatingWebhookCABundle(ctrl.clientConfig, validatingWebhook); err != nil {
+		return nil, err
+	}
+	if err := reg_util.UpdateMutatingWebhookCABundle(ctrl.clientConfig, mutatingWebhook); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -75,9 +75,12 @@ func (c *Controller) ensureCustomResourceDefinitions() error {
 func (c *Controller) Run(stopCh <-chan struct{}) {
 	go c.RunInformers(stopCh)
 
-	cancel, _ := reg_util.SyncValidatingWebhookCABundle(c.clientConfig, validatingWebhook)
+	cancelValidatingWebhook, _ := reg_util.SyncValidatingWebhookCABundle(c.clientConfig, validatingWebhook)
+	cancelMutatingWebhook, _ := reg_util.SyncMutatingWebhookCABundle(c.clientConfig, mutatingWebhook)
+
 	<-stopCh
-	cancel()
+	cancelValidatingWebhook()
+	cancelMutatingWebhook()
 }
 
 func (c *Controller) RunInformers(stopCh <-chan struct{}) {

--- a/pkg/controller/workplan.go
+++ b/pkg/controller/workplan.go
@@ -17,10 +17,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func (c *Controller) NewWorkplanWebhook() hooks.AdmissionHook {
+func (c *Controller) NewWorkplanMutatingWebhook() hooks.AdmissionHook {
 	return webhook.NewGenericWebhook(
 		schema.GroupVersionResource{
-			Group:    "admission.engine.kube.ci",
+			Group:    "validators.engine.kube.ci",
 			Version:  "v1alpha1",
 			Resource: "workplans",
 		},

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -116,8 +116,9 @@ func (c completedConfig) New() (*KubeciServer, error) {
 		return nil, err
 	}
 	admissionHooks := []hooks.AdmissionHook{
-		ctrl.NewWorkflowWebhook(),
-		ctrl.NewWorkplanWebhook(),
+		ctrl.NewWorkflowValidatingWebhook(),
+		ctrl.NewWorkflowMutatingWebhook(),
+		ctrl.NewWorkplanMutatingWebhook(),
 	}
 
 	s := &KubeciServer{

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -92,14 +92,15 @@ var _ = AfterSuite(func() {
 	By("Cleaning API server and Webhook stuff")
 
 	if options.EnableWebhook && !options.SelfHostedOperator {
-		root.KubeClient.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Delete("admission.engine.kube.ci", meta.DeleteInBackground())
-		root.KubeClient.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Delete("admission.engine.kube.ci", meta.DeleteInBackground())
+		root.KubeClient.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Delete("mutators.engine.kube.ci", meta.DeleteInBackground())
+		root.KubeClient.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Delete("validators.engine.kube.ci", meta.DeleteInBackground())
 	}
 
 	if !options.SelfHostedOperator {
 		root.KubeClient.CoreV1().Endpoints(root.Namespace()).Delete("kubeci-dev-apiserver", meta.DeleteInBackground())
 		root.KubeClient.CoreV1().Services(root.Namespace()).Delete("kubeci-dev-apiserver", meta.DeleteInBackground())
-		root.KAClient.ApiregistrationV1beta1().APIServices().Delete("v1alpha1.admission.engine.kube.ci", meta.DeleteInBackground())
+		root.KAClient.ApiregistrationV1beta1().APIServices().Delete("v1alpha1.validators.engine.kube.ci", meta.DeleteInBackground())
+		root.KAClient.ApiregistrationV1beta1().APIServices().Delete("v1alpha1.mutators.engine.kube.ci", meta.DeleteInBackground())
 		root.KAClient.ApiregistrationV1beta1().APIServices().Delete("v1alpha1.extensions.kube.ci", meta.DeleteInBackground())
 	}
 	root.DeleteNamespace(root.Namespace())

--- a/test/e2e/framework/operator.go
+++ b/test/e2e/framework/operator.go
@@ -55,7 +55,8 @@ func (f *Framework) StartAPIServerAndOperator(kubeConfigPath string, extraOption
 
 func (f *Framework) EventuallyAPIServerReady() GomegaAsyncAssertion {
 	apiServices := []string{
-		"v1alpha1.admission.engine.kube.ci",
+		"v1alpha1.validators.engine.kube.ci",
+		"v1alpha1.mutators.engine.kube.ci",
 		"v1alpha1.extensions.kube.ci",
 	}
 


### PR DESCRIPTION
- `workflow.spec.executionOrder` defaulted to `Serial` using mutator
- Renamed API group `admission.engine.kube.ci` to `validators.engine.kube.ci`
- Added new API group `mutators.engine.kube.ci`

xref: kube-ci/project#26